### PR TITLE
Revert "nemu/include/debug.h: improve the robustness"

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -36,7 +36,7 @@ extern FILE* log_fp;
       fprintf(stderr, "\33[1;31m"); \
       fprintf(stderr, __VA_ARGS__); \
       fprintf(stderr, "\33[0m\n"); \
-      assert(0); \
+      assert(cond); \
     } \
   } while (0)
 


### PR DESCRIPTION
Reverts NJU-ProjectN/nemu#7

It is not encouraged to put expressions with side-effects into `assert()`. See `man assert` for more details.