### PR TITLE
monitor,debug,log: fix buffer overflow after LOG_MAX

### DIFF
--- a/src/monitor/cpu-exec.c
+++ b/src/monitor/cpu-exec.c
@@ -21,6 +21,7 @@ void interpret_rtl_exit(int state, vaddr_t halt_pc, uint32_t halt_ret) {
 vaddr_t exec_once(void);
 void difftest_step(vaddr_t ori_pc, vaddr_t next_pc);
 void asm_print(vaddr_t ori_pc, int instr_len, bool print_flag);
+void log_clearbuf(void);
 
 static uint64_t g_nr_guest_instr = 0;
 
@@ -57,6 +58,7 @@ void cpu_exec(uint64_t n) {
               "we do not record more instruction trace beyond this point.\n"
               "To capture more trace, you can modify the LOG_MAX macro in %s\n\n", __FILE__);
   }
+  log_clearbuf();
 
     /* TODO: check watchpoints here. */
 

--- a/src/monitor/debug/log.c
+++ b/src/monitor/debug/log.c
@@ -28,7 +28,9 @@ void asm_print(vaddr_t ori_pc, int instr_len, bool print_flag) {
   if (print_flag) {
     puts(tempbuf);
   }
+}
 
+void log_clearbuf(void) {
   log_bytebuf[0] = '\0';
   log_asmbuf[0] = '\0';
 }


### PR DESCRIPTION
* Previously instr_fetch() still call strcatf() after LOG_MAX, but we
  only clear the buffer in the end of asm_print(), which is only invoked
  before LOG_MAX. This causes buffer overflow. To fix this , we clear
  the buffer after the execution of every instructions.