### PR TITLE
Make BITMASK macro safer

### DIFF
--- a/include/macro.h
+++ b/include/macro.h
@@ -12,7 +12,7 @@
 
 #define MAP(c, f) c(f)
 
-#define BITMASK(bits) ((1 << (bits)) - 1)
+#define BITMASK(bits) ((1ull << (bits)) - 1)
 #define BITS(x, hi, lo) (((x) >> (lo)) & BITMASK((hi) - (lo) + 1)) // similar to x[hi:lo] in verilog
 #define SEXT(x, len) ({ struct { int64_t n : len; } __x = { .n = x }; (int64_t)__x.n; })
 


### PR DESCRIPTION
Use 1ull in shifting to avoid undefined behavior

If users call the original BITMASK(32), the result is undefined.
See also https://stackoverflow.com/questions/2648764/whats-bad-about-shifting-a-32-bit-variable-32-bits