### PR TITLE
monitor: fix segment fault with Spike as REF

### DIFF
--- a/src/monitor/monitor.c
+++ b/src/monitor/monitor.c
@@ -69,7 +69,7 @@ static int parse_args(int argc, char *argv[]) {
       case 'p': sscanf(optarg, "%d", &difftest_port); break;
       case 'l': log_file = optarg; break;
       case 'd': diff_so_file = optarg; break;
-      case 1: img_file = optarg; return optind - 1;
+      case 1: img_file = optarg; return 0;
       default:
         printf("Usage: %s [OPTION...] IMAGE [args]\n\n", argv[0]);
         printf("\t-b,--batch              run with batch mode\n");


### PR DESCRIPTION
* This is caused by wrong symbol resolution of `optind`.
* When NEMU is compiled with -O0 or -Og, the accessing of `optind` in
  `parse_args()` is kept. Such reference is handled by COPY RELOCATION
  during linking, which will create a local copy of `optind` in NEMU and
  redirect the reference of `optind` in glibc to such copy. For more
  information, refer to such slide[1].
* Spike also accesses `optind` when it compiles to an ELF. However, when
  it is compiled to a shared object, the reference is resolved to the
  global object in glibc.
* Here is the problem. When NEMU loads Spike with `dlopen()`, Spike
  continues to reset the `optind` in glibc to 0. But when Spike calls
  `getopt()` in glibc, the reference of `optind` in glibc is already
  redirected to the local copy inside NEMU, which is not the one reset
  to 0 by Spike.
* When there are enough arguments passed to NEMU, the `optind` of the
  local copy inside NEMU will remain to a large number. Such number will
  be used as an index when the glibc functions are called by Spike,
  causing a segmentation fault.

* To fix this issue, there are solutions below.
  + remove unused reference of `optind` in NEMU to remove the local copy
    (which is adopted by this patch)
  + compile NEMU with `-fPIC` to remove the local copy
  + remove `RTLD_DEEPBIND` when calling `dlopen()`, which makes the
    reference of `optind` in Spike resolved to the local copy inside
    NEMU

* Thanks @huaixv to find the root cause of this issue.

[1]: https://www.ndss-symposium.org/wp-content/uploads/2017/09/ndss2017_09-4-ge_slides.pdf