### PR TITLE
cpu: flip byte order of instructions printing

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -36,7 +36,7 @@ static void exec_once(Decode *s, vaddr_t pc) {
   int ilen = s->snpc - s->pc;
   int i;
   uint8_t *inst = (uint8_t *)&s->isa.inst.val;
-  for (i = 0; i < ilen; i ++) {
+  for (i = ilen - 1; i >= 0; i --) {
     p += snprintf(p, 4, " %02x", inst[i]);
   }
   int ilen_max = MUXDEF(CONFIG_ISA_x86, 8, 4);


### PR DESCRIPTION
考虑到教程默认我们使用的机器是小端序的, 我建议在`exec_once()`中输出指令hex时按指令长度翻转一下, 从
![image](https://user-images.githubusercontent.com/37630203/162734268-f9c1318b-e12e-4f84-83c0-17d0407adbb8.png)
变成
![image](https://user-images.githubusercontent.com/37630203/162734408-f1fb1033-ec49-4f12-89b8-5497efa75c8f.png)

比如对于RV32这样操作数长度为7位, 而不是整字节长度的指令集来说, 按内存数组地址递增顺序按字节打印指令并没有太大意义 (甚至一开始误导了我) 😂