### PR TITLE
Makefile: use ALL_CFLAGS for local CFLAGS instead, leave CFLAGS to user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CFLAGS_BUILD += $(if $(CONFIG_CC_LTO),-flto,)
 CFLAGS_BUILD += $(if $(CONFIG_CC_DEBUG),-Og -ggdb3,)
 CFLAGS_BUILD += $(if $(CONFIG_CC_ASAN),-fsanitize=address,)
 CFLAGS_TRACE += -DITRACE_COND=$(if $(CONFIG_ITRACE_COND),$(call remove_quote,$(CONFIG_ITRACE_COND)),true)
-CFLAGS  += $(CFLAGS_BUILD) $(CFLAGS_TRACE) -D__GUEST_ISA__=$(GUEST_ISA)
+ALL_CFLAGS  += $(CFLAGS_BUILD) $(CFLAGS_TRACE) -D__GUEST_ISA__=$(GUEST_ISA) $(CFLAGS)
 LDFLAGS += $(CFLAGS_BUILD)
 
 # Include rules for menuconfig

--- a/include/isa.h
+++ b/include/isa.h
@@ -4,7 +4,7 @@
 // Located at src/isa/$(GUEST_ISA)/include/isa-def.h
 #include <isa-def.h>
 
-// The macro `__GUEST_ISA__` is defined in $(CFLAGS).
+// The macro `__GUEST_ISA__` is defined in $(ALL_CFLAGS).
 // It will be expanded as "x86" or "mips32" ...
 typedef concat(__GUEST_ISA__, _CPU_state) CPU_state;
 typedef concat(__GUEST_ISA__, _ISADecodeInfo) ISADecodeInfo;

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -3,7 +3,7 @@
 # Add necessary options if the target is a shared library
 ifeq ($(SHARE),1)
 SO = -so
-CFLAGS  += -fPIC
+ALL_CFLAGS  += -fPIC
 LDFLAGS += -rdynamic -shared -fPIC
 endif
 
@@ -22,7 +22,7 @@ CXX := g++
 endif
 LD := $(CXX)
 INCLUDES = $(addprefix -I, $(INC_PATH))
-CFLAGS  := -O2 -MMD -Wall -Werror $(INCLUDES) $(CFLAGS)
+ALL_CFLAGS  := -O2 -MMD -Wall -Werror $(INCLUDES) $(ALL_CFLAGS)
 LDFLAGS := -O2 $(LDFLAGS)
 
 OBJS = $(SRCS:%.c=$(OBJ_DIR)/%.o) $(CXXSRC:%.cc=$(OBJ_DIR)/%.o)
@@ -31,13 +31,13 @@ OBJS = $(SRCS:%.c=$(OBJ_DIR)/%.o) $(CXXSRC:%.cc=$(OBJ_DIR)/%.o)
 $(OBJ_DIR)/%.o: %.c
 	@echo + CC $<
 	@mkdir -p $(dir $@)
-	@$(CC) $(CFLAGS) -c -o $@ $<
+	@$(CC) $(ALL_CFLAGS) -c -o $@ $<
 	$(call call_fixdep, $(@:.o=.d), $@)
 
 $(OBJ_DIR)/%.o: %.cc
 	@echo + CXX $<
 	@mkdir -p $(dir $@)
-	@$(CXX) $(CFLAGS) $(CXXFLAGS) -c -o $@ $<
+	@$(CXX) $(ALL_CFLAGS) $(CXXFLAGS) -c -o $@ $<
 	$(call call_fixdep, $(@:.o=.d), $@)
 
 # Depencies

--- a/tools/kconfig/Makefile
+++ b/tools/kconfig/Makefile
@@ -3,7 +3,7 @@ obj := build
 SRCS += confdata.c expr.c preprocess.c symbol.c util.c
 SRCS += $(obj)/lexer.lex.c $(obj)/parser.tab.c
 CC = gcc
-CFLAGS += -DYYDEBUG
+ALL_CFLAGS += -DYYDEBUG
 INC_PATH += .
 
 ifeq ($(NAME),conf)

--- a/tools/qemu-diff/Makefile
+++ b/tools/qemu-diff/Makefile
@@ -2,7 +2,7 @@ NAME  = $(GUEST_ISA)-qemu
 SRCS  = $(shell find src/ -name "*.c")
 
 SHARE = 1
-CFLAGS += -DNEMU_HOME=\"$(NEMU_HOME)\" -DCONFIG_ISA_$(GUEST_ISA)
+ALL_CFLAGS += -DNEMU_HOME=\"$(NEMU_HOME)\" -DCONFIG_ISA_$(GUEST_ISA)
 INC_PATH += $(NEMU_HOME)/include
 
 include $(NEMU_HOME)/scripts/build.mk


### PR DESCRIPTION
参照[GNU的编程规范的说明](https://www.gnu.org/prep/standards/html_node/Command-Variables.html#Command-Variables)`CFLAGS`这个变量应当是完全留给用户使用的, 用法比如:
```C
// src/monitor/sdb/expr.c
#ifdef DEBUG_expr
printf("%d\n", value);
#endif // DEBUG_expr
```
然后用`make run CFLAGS=-DDEBUG_expr`来编译运行, 实现加这个参数才打印这部分信息的效果 (当然不想看这信息了下次编译前得`make clean`). 这样我就可以在Makefile之外自由指定一些编译选项

现在项目中直接使用CFLAGS了我试了下果然`make clean && make run CFLAGS=-DDEBUG_expr`会因为覆盖掉了其他在**Makefile**中设置的编译选项导致编译失败. 改起来也很简单, 我只是参照GNU的写法把原本的`CFLAGS`替换为了`ALL_CFLAGS`然后将`CFLAGS`加在了主**Makefile**的`ALL_CFLAGS`赋值的最后就OK了.