### PR TITLE
[fix]修复init_mem和out_of_bound和in_pmem函数中paddr右边界的计算

### DIFF
--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -11,7 +11,7 @@ uint8_t* guest_to_host(paddr_t paddr);
 paddr_t host_to_guest(uint8_t *haddr);
 
 static inline bool in_pmem(paddr_t addr) {
-  return (addr >= CONFIG_MBASE) && (addr < (paddr_t)CONFIG_MBASE + CONFIG_MSIZE);
+  return (addr >= CONFIG_MBASE) && (addr - CONFIG_MSIZE < (paddr_t)CONFIG_MBASE);
 }
 
 word_t paddr_read(paddr_t addr, int len);

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -22,8 +22,8 @@ static void pmem_write(paddr_t addr, int len, word_t data) {
 }
 
 static void out_of_bound(paddr_t addr) {
-  panic("address = " FMT_PADDR " is out of bound of pmem [" FMT_PADDR ", " FMT_PADDR ") at pc = " FMT_WORD,
-      addr, CONFIG_MBASE, CONFIG_MBASE + CONFIG_MSIZE, cpu.pc);
+  panic("address = " FMT_PADDR " is out of bound of pmem [" FMT_PADDR ", " FMT_PADDR "] at pc = " FMT_WORD,
+      addr, CONFIG_MBASE, CONFIG_MBASE + CONFIG_MSIZE - 1, cpu.pc);
 }
 
 void init_mem() {
@@ -39,7 +39,7 @@ void init_mem() {
   }
 #endif
   Log("physical memory area [" FMT_PADDR ", " FMT_PADDR "]",
-      (paddr_t)CONFIG_MBASE, (paddr_t)CONFIG_MBASE + CONFIG_MSIZE);
+      (paddr_t)CONFIG_MBASE, (paddr_t)CONFIG_MBASE + CONFIG_MSIZE - 1);
 }
 
 word_t paddr_read(paddr_t addr, int len) {


### PR DESCRIPTION
当内存地址最大值(CONFIG_MBASE + CONFIG_MSIZE - 1)需要用paddr_t的最大值来表示时。CONFIG_MBASE + CONFIG_MSIZE会溢出并得到0，输出和判断是否超出内存范围都会出现问题。
因此，输出时使用闭区间，判断时移项来避免溢出。
另外，init_mem()函数中，log输出了闭区间，但是右边界不准确。