### PR TITLE
Fix/paddr out_of_bound() in_pmem()

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -15,9 +15,12 @@
 #include <stdlib.h>
 #endif
 
-#if CONFIG_MBASE + CONFIG_MSIZE > 0x100000000ul
+#if CONFIG_MBASE_CONF + CONFIG_MSIZE_CONF > 0x100000000ul
 #define PMEM64 1
 #endif
+
+#define CONFIG_MBASE (paddr_t)CONFIG_MBASE_CONF
+#define CONFIG_MSIZE (paddr_t)CONFIG_MSIZE_CONF
 
 typedef MUXDEF(CONFIG_ISA64, uint64_t, uint32_t) word_t;
 typedef MUXDEF(CONFIG_ISA64, int64_t, int32_t)  sword_t;

--- a/include/memory/paddr.h
+++ b/include/memory/paddr.h
@@ -11,7 +11,7 @@ uint8_t* guest_to_host(paddr_t paddr);
 paddr_t host_to_guest(uint8_t *haddr);
 
 static inline bool in_pmem(paddr_t addr) {
-  return (addr >= CONFIG_MBASE) && (addr - CONFIG_MSIZE < (paddr_t)CONFIG_MBASE);
+  return (addr >= CONFIG_MBASE) && (addr - CONFIG_MBASE < CONFIG_MSIZE);
 }
 
 word_t paddr_read(paddr_t addr, int len);

--- a/src/memory/Kconfig
+++ b/src/memory/Kconfig
@@ -1,11 +1,11 @@
 menu "Memory Configuration"
 
-config MBASE
+config MBASE_CONF
   hex "Memory base address"
   default 0x0        if ISA_x86
   default 0x80000000
 
-config MSIZE
+config MSIZE_CONF
   hex "Memory size"
   default 0x8000000
 

--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -39,7 +39,7 @@ void init_mem() {
   }
 #endif
   Log("physical memory area [" FMT_PADDR ", " FMT_PADDR "]",
-      (paddr_t)CONFIG_MBASE, (paddr_t)CONFIG_MBASE + CONFIG_MSIZE - 1);
+      CONFIG_MBASE, CONFIG_MBASE + CONFIG_MSIZE - 1);
 }
 
 word_t paddr_read(paddr_t addr, int len) {


### PR DESCRIPTION
`in_pmem()`中，应同时减去`MBASE`，上个PR中为减去`MSIZE`，减`MBASE`的好处为，若`addr - CONFIG_MBASE`为负数，将得到一个大于等于`CONFIG_MSIZE`的值（根据无符号数的补码运算），即`(addr - CONFIG_MBASE < CONFIG_MSIZE)`可以判断`addr >= CONFIG_MBASE && addr < CONFIG_MBASE + CONFIG_MSIZE`，但若减去`MSIZE`，则在`addr < CONFIG_MSIZE`时会出现问题。
另外，MBASE和MSIZE应该是paddr_t类型的，但是宏定义中并未限定类型，在commom.h中修改。