### PR TITLE
修改了译码的表达方式，使INSTPAT更好写

### DIFF
--- a/src/isa/riscv64/inst.c
+++ b/src/isa/riscv64/inst.c
@@ -27,44 +27,40 @@ enum {
   TYPE_N, // none
 };
 
-#define src1R(n) do { *src1 = R(n); } while (0)
-#define src2R(n) do { *src2 = R(n); } while (0)
-#define destR(n) do { *dest = n; } while (0)
-#define src1I(i) do { *src1 = i; } while (0)
-#define src2I(i) do { *src2 = i; } while (0)
-#define destI(i) do { *dest = i; } while (0)
+#define src1R() do { *src1 = R(rs1); } while (0)
+#define src2R() do { *src2 = R(rs2); } while (0)
+#define immI() do { *imm = SEXT(BITS(i, 31, 20), 12); } while(0)
+#define immU() do { *imm = SEXT(BITS(i, 31, 12), 20) << 12; } while(0)
+#define immS() do { *imm = (SEXT(BITS(i, 31, 25), 7) << 5) | BITS(i, 11, 7); } while(0)
 
-static word_t immI(uint32_t i) { return SEXT(BITS(i, 31, 20), 12); }
-static word_t immU(uint32_t i) { return SEXT(BITS(i, 31, 12), 20) << 12; }
-static word_t immS(uint32_t i) { return (SEXT(BITS(i, 31, 25), 7) << 5) | BITS(i, 11, 7); }
-
-static void decode_operand(Decode *s, word_t *dest, word_t *src1, word_t *src2, int type) {
+static void decode_operand(Decode *s, int *dest, word_t *src1, word_t *src2, word_t *imm, int type) {
   uint32_t i = s->isa.inst.val;
   int rd  = BITS(i, 11, 7);
   int rs1 = BITS(i, 19, 15);
   int rs2 = BITS(i, 24, 20);
-  destR(rd);
+  *dest = rd;
   switch (type) {
-    case TYPE_I: src1R(rs1);     src2I(immI(i)); break;
-    case TYPE_U: src1I(immU(i)); break;
-    case TYPE_S: destI(immS(i)); src1R(rs1); src2R(rs2); break;
+    case TYPE_I: src1R();          immI(); break;
+    case TYPE_U:                   immU(); break;
+    case TYPE_S: src1R(); src2R(); immS(); break;
   }
 }
 
 static int decode_exec(Decode *s) {
-  word_t dest = 0, src1 = 0, src2 = 0;
+  int dest = 0;
+  word_t src1 = 0, src2 = 0, imm = 0;
   s->dnpc = s->snpc;
 
 #define INSTPAT_INST(s) ((s)->isa.inst.val)
 #define INSTPAT_MATCH(s, name, type, ... /* body */ ) { \
-  decode_operand(s, &dest, &src1, &src2, concat(TYPE_, type)); \
+  decode_operand(s, &dest, &src1, &src2, &imm, concat(TYPE_, type)); \
   __VA_ARGS__ ; \
 }
 
   INSTPAT_START();
-  INSTPAT("??????? ????? ????? ??? ????? 00101 11", auipc  , U, R(dest) = src1 + s->pc);
-  INSTPAT("??????? ????? ????? 011 ????? 00000 11", ld     , I, R(dest) = Mr(src1 + src2, 8));
-  INSTPAT("??????? ????? ????? 011 ????? 01000 11", sd     , S, Mw(src1 + dest, 8, src2));
+  INSTPAT("??????? ????? ????? ??? ????? 00101 11", auipc  , U, R(dest) = s->pc + imm);
+  INSTPAT("??????? ????? ????? 011 ????? 00000 11", ld     , I, R(dest) = Mr(src1 + imm, 8));
+  INSTPAT("??????? ????? ????? 011 ????? 01000 11", sd     , S, Mw(src1 + imm, 8, src2));
 
   INSTPAT("0000000 00001 00000 000 00000 11100 11", ebreak , N, NEMUTRAP(s->pc, R(10))); // R(10) is $a0
   INSTPAT("??????? ????? ????? ??? ????? ????? ??", inv    , N, INV(s->pc));


### PR DESCRIPTION
# NEMU-riscv64译码修改

指令中给出的有关操作数的信息有：目的寄存器、源寄存器（2个）、立即数，其中目的寄存器和源寄存器以索引的方式给出，即从指令中可以取到这些寄存器的索引（rd、rs1、rs2）。

在”执行“阶段之前，需要取得参与运算的数，这些数的来源有：源寄存器、立即数、PC，其中来自源寄存器的数需要通过索引访问寄存器组取得，立即数从指令中根据指令类型取出相应位进行拼接得到，PC则可以直接取。

所以`decode_operand`函数要完成以下几件事：

1. 从指令的指定字段取得寄存器索引（rd、rs1、rs2）
  
2. 根据指令类型从寄存器组取出数据（src1、src2）
  
3. 根据指令类型从指令中取出立即数（imm）
  

```c
// dest表示目的寄存器索引， src1、src2分别表示从rs1、rs2取出的数据， imm表示从指令中取得的立即数
static void decode_operand(Decode *s, int *dest, word_t *src1, word_t *src2, word_t *imm, int type) {
  uint32_t i = s->isa.inst.val;
  int rd  = BITS(i, 11, 7);
  int rs1 = BITS(i, 19, 15);
  int rs2 = BITS(i, 24, 20);
  *dest = rd;
  switch (type) {    // 根据指令类型决定是否从rs1、rs2取数，是否要取立即数（按哪种方式取）
    case TYPE_I: src1R();          immI(); break;
    case TYPE_U:                   immU(); break;
    case TYPE_S: src1R(); src2R(); immS(); break;
  }
}
```

接下来在“执行”阶段，就可以用前面取到的操作数（src1、src2、imm、pc等）进行相应的操作，然后将结果写回寄存器或写入内存。这样很容易根据手册中定义的指令行为来编写相应的C语言代码。写回寄存器时根据译码阶段取得的索引（dest）访问寄存器组，用`R(dest) = 结果`表示。读写内存使用Mr、Mw函数，且riscv中访存地址一定为src1和imm相加的结果，所以访存函数就写成`Mr(src1 + imm, LEN)`和`Mw(src1 + imm, LEN, DATA)`的形式。

```c
// auipc
// 将pc与立即数相加，写入rd中
R(dest) = s->pc + imm
```

```c
// ld
// 从内存(addr=src1+imm)中取出8个字节写入rd
R(dest) = Mr(src1 + imm, 8)
```

```c
// sd
// 将从rs2中取出的数写入内存(addr=src1+imm)
Mw(src1 + imm, 8, src2)
```

另外，`pc+4`可以用`s->snpc`表示，将结果写回pc用`s->dnpc = 结果`表示。

根据上述思路，可以很容易地完成所有指令的INSTPAT。更进一步，可以在INSTPAT的区域定义更多的宏，写起来更自然（可以参考[riscv-card](https://github.com/NJU-ProjectN/nemu/files/9161814/riscv-card.pdf)）。（思路源自@LeoJhonSong）

```c
#define rd R(dest)
#define rs1 src1
#define rs2 src2
#define pc s->pc
#define snpc s->snpc
#define dnpc s->dnpc
#define addr (src1+imm)
...
INSTPAT(..., auipc, U, rd = pc + imm);
INSTPAT(..., ld,    I, rd = Mr(addr, 8));
INSTPAT(..., sd,    S, Mw(addr, 8, rs2));
...
INSTPAT(..., jal,   J, rd = snpc; dnpc = pc + imm);
...
#undef rd
#undef rs1
#undef rs2
#undef pc
#undef snpc
#undef dnpc
#undef addr
```