### PR TITLE
fix the macro conflict with sys/_types/_key_t.h on macos

### DIFF
--- a/src/device/keyboard.c
+++ b/src/device/keyboard.c
@@ -33,6 +33,11 @@ f(UP) f(DOWN) f(LEFT) f(RIGHT) f(INSERT) f(DELETE) f(HOME) f(END) f(PAGEUP) f(PA
 
 #define _KEY_NAME(k) _KEY_##k,
 
+// It's conflicted on macos with sys/_types/_key_t.h
+#ifdef __APPLE__
+  #undef _KEY_T 
+#endif
+
 enum {
   _KEY_NONE = 0,
   MAP(_KEYS, _KEY_NAME)


### PR DESCRIPTION
如[issue](https://github.com/NJU-ProjectN/ics-pa/issues/18)提到,解决了此冲突问题