### PR TITLE
fix: compile error on ./nemu/tools/gen-expr/gen-expr.c

### DIFF
--- a/tools/gen-expr/gen-expr.c
+++ b/tools/gen-expr/gen-expr.c
@@ -60,7 +60,7 @@ int main(int argc, char *argv[]) {
     assert(fp != NULL);
 
     int result;
-    fscanf(fp, "%d", &result);
+    ret = fscanf(fp, "%d", &result);
     pclose(fp);
 
     printf("%u %s\n", result, buf);


### PR DESCRIPTION
I use Ubuntu 22.04.2 LTS
the default gcc version is `11.3.0 (Ubuntu 11.3.0-1ubuntu1~22.04)`
```
~/Desktop/github/ics2022/nemu/tools/gen-expr pa1 !1
> make
+ CC gen-expr.c
gen-expr.c: In function ‘main’:
gen-expr.c:63:5: error: ignoring return value of ‘fscanf’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
   63 |     fscanf(fp, "%d", &result);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [/home/junyu33/Desktop/github/ics2022/nemu/scripts/build.mk:34: /home/junyu33/Desktop/github/ics2022/nemu/tools/gen-expr/build/obj-gen-expr/gen-expr.o] Error 1
```

btw, the course is wonderful and I've learnt a lot which is practical for me.