### PR TITLE
小改进：反汇编时禁用aliases

### DIFF
--- a/src/utils/disasm.cc
+++ b/src/utils/disasm.cc
@@ -88,6 +88,8 @@ extern "C" void init_disasm(const char *triple) {
       AsmInfo->getAssemblerDialect(), *AsmInfo, *gMII, *gMRI);
   gIP->setPrintImmHex(true);
   gIP->setPrintBranchImmAsAddress(true);
+  if (isa == "riscv32" || isa == "riscv64")
+    gIP->applyTargetSpecificCLOption("no-aliases");
 }
 
 extern "C" void disassemble(char *str, int size, uint64_t pc, uint8_t *code, int nbyte) {


### PR DESCRIPTION
在实际调试过程中，itrace更关心的应该是「处理器执行了什么指令」而不是「这段程序的汇编代码是什么」，因此输出的trace中没有必要使用指令别名，可以更容易从log中定位到指令实现。