### PR TITLE
fix: link to libtinfo.so if using Gentoo

### DIFF
--- a/tools/kconfig/Makefile
+++ b/tools/kconfig/Makefile
@@ -5,6 +5,11 @@ SRCS += $(obj)/lexer.lex.c $(obj)/parser.tab.c
 CC = gcc
 CFLAGS += -DYYDEBUG
 INC_PATH += .
+DISTRO = $(shell cat /etc/os-release | grep PRETTY_NAME | sed 's/PRETTY_NAME=//')
+
+ifeq ($(DISTRO),"Gentoo Linux")
+LIBS += -ltinfo
+endif
 
 ifeq ($(NAME),conf)
 SRCS += conf.c


### PR DESCRIPTION
I came up with this solution, please notice me if there is a better way. Thanks!