### PR TITLE
Fix weird sdl behavior under wayland environment.

### DIFF
--- a/src/device/vga.c
+++ b/src/device/vga.c
@@ -53,6 +53,7 @@ static void init_screen() {
   SDL_SetWindowTitle(window, title);
   texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,
       SDL_TEXTUREACCESS_STATIC, SCREEN_W, SCREEN_H);
+  SDL_RenderPresent(renderer);
 }
 
 static inline void update_screen() {


### PR DESCRIPTION
While working on PA2 keyboard section, I noticed that with SDL_VIDEODRIVER=wayland, the SDL window won't pop out when running am-test mainargs=k, making it impossible to continue.
As stated here: [SDL docs](https://github.com/libsdl-org/SDL/blob/main/docs/README-wayland.md), wayland requires that the application initially present a buffer before the window becomes visible. So simply render right after the window is created would do.