### PR TITLE
Slightly improve performance of init_mem

### DIFF
--- a/src/memory/paddr.c
+++ b/src/memory/paddr.c
@@ -17,6 +17,7 @@
 #include <memory/paddr.h>
 #include <device/mmio.h>
 #include <isa.h>
+#include <sys/random.h>
 
 #if   defined(CONFIG_PMEM_MALLOC)
 static uint8_t *pmem = NULL;
@@ -47,11 +48,8 @@ void init_mem() {
   assert(pmem);
 #endif
 #ifdef CONFIG_MEM_RANDOM
-  uint32_t *p = (uint32_t *)pmem;
-  int i;
-  for (i = 0; i < (int) (CONFIG_MSIZE / sizeof(p[0])); i ++) {
-    p[i] = rand();
-  }
+  int ret = getrandom(pmem, CONFIG_MSIZE, 0);
+  assert(ret == CONFIG_MSIZE);
 #endif
   Log("physical memory area [" FMT_PADDR ", " FMT_PADDR "]", PMEM_LEFT, PMEM_RIGHT);
 }


### PR DESCRIPTION
The advantage of using `getrandom`  is that it allows bulk filling of  `pmem` , as opposed to the byte-by-byte filling required by `rand`.

This change has led to a tiny optimization. Reducing the runtime about 200 milliseconds.

However, a side effect of this change is that when TARGET_AM is set. init_mem will no longer fill `pmem` with exact same random bytes every time. Given that `getrandom` is not affect by `srand`. (I am not sure if it matters.)

I can add a  `#ifdef CONFIG_TARGET_AM`  if necessary.

