### PR TITLE
[FIX] src/utils/log.c: TARGET_AM cannot support file r&w

### DIFF
--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -16,6 +16,8 @@
 #include <common.h>
 
 extern uint64_t g_nr_guest_inst;
+
+#ifndef CONFIG_TARGET_AM
 FILE *log_fp = NULL;
 
 void init_log(const char *log_file) {
@@ -32,3 +34,4 @@ bool log_enable() {
   return MUXDEF(CONFIG_TRACE, (g_nr_guest_inst >= CONFIG_TRACE_START) &&
          (g_nr_guest_inst <= CONFIG_TRACE_END), false);
 }
+#endif


### PR DESCRIPTION
When as AM target, nemu cannot use some glibc functions like `fopen` & `fclose`. Even if the macro `CONFIG_TARGET_AM` is applied, this file will still be compiled by the cross-compiler. The reason why it did not go wrong is probably that the compiler optimized it and this object file(or the function) didn't participate in linking process. I think it is not a good idea and we shall add explicit conditional compile statements.

To find such kinds of problems, some clever methods could be further applied(though I don't do them in this PR):

**Add conditional compile statements when using glibc functions.** E.g. `#include <string.h>` in common.h; `#include  <stdio.h>` in debug.h (Note: this is also the source where the compiler get the declaration of `fopen` and `fclose` in this PR so that it does not report error when compiling), etc. Add conditional comile statements with `#include <klib.h>` instead.