### PR TITLE
[FIX] spike-diff/difftest.cc: flush the tlb before copy memory towards ref

### DIFF
--- a/tools/spike-diff/difftest.cc
+++ b/tools/spike-diff/difftest.cc
@@ -72,6 +72,7 @@ void sim_t::diff_set_regs(void* diff_context) {
 
 void sim_t::diff_memcpy(reg_t dest, void* src, size_t n) {
   mmu_t* mmu = p->get_mmu();
+  mmu->flush_tlb();
   for (size_t i = 0; i < n; i++) {
     mmu->store<uint8_t>(dest+i, *((uint8_t*)src+i));
   }


### PR DESCRIPTION
Without flushing the tlb before copy memory towards ref, the copying may result in wrong results on ref.

*Why I found this problem*: The reason is interesting and can serve as an example of how things go wrong. The issue I met is that when implementing difftest detach & attach in PA3, I copied a series of instructions to RESET_VECTOR like `csrw ...` to set the CSR on ref properly. I copied momory two times: one for `csrw` instrucctions, and the other for the whole dut memory. However, my difftest results tell me that **the second copy didn't work as expected**. And I found that there is an icache in spike, which is not flushed properly in the interface functions provided, thus the latter copy didn't work.