### PR TITLE
fix: environment variable CC cause menuconfig failed to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ SRCS-y += $(shell find -L $(DIRS-y) -name "*.c")
 SRCS = $(filter-out $(SRCS-BLACKLIST-y),$(SRCS-y))
 
 # Extract compiler and options from menuconfig
+ifneq ($(CONFIG_CC),)
 CC = $(call remove_quote,$(CONFIG_CC))
+endif
 CFLAGS_BUILD += $(call remove_quote,$(CONFIG_CC_OPT))
 CFLAGS_BUILD += $(if $(CONFIG_CC_LTO),-flto,)
 CFLAGS_BUILD += $(if $(CONFIG_CC_DEBUG),-Og -ggdb3,)


### PR DESCRIPTION
This closes #84.