### PR TITLE
Fixed: segmentation fault when calling Log macro too early

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -60,7 +60,7 @@ uint64_t get_time();
   do { \
     extern FILE* log_fp; \
     extern bool log_enable(); \
-    if (log_enable()) { \
+    if (log_enable() && log_fp != NULL) { \
       fprintf(log_fp, __VA_ARGS__); \
       fflush(log_fp); \
     } \


### PR DESCRIPTION
捉个小虫，用户如果太早调Log或者没指定对logfile会segment fault.
现在就算早调至少也有命令行输出了。
