### PR TITLE
patch: Ics2017 两处框架相关的bug

### DIFF
--- a/src/cpu/exec/exec.c
+++ b/src/cpu/exec/exec.c
@@ -235,7 +235,7 @@ void exec_wrapper(bool print_flag) {
 #ifdef DEBUG
   int instr_len = decoding.seq_eip - cpu.eip;
   sprintf(decoding.p, "%*.s", 50 - (12 + 3 * instr_len), "");
-  strcat(decoding.asm_buf, decoding.assembly);
+  strncat(decoding.asm_buf, decoding.assembly, 80);
   Log_write("%s\n", decoding.asm_buf);
   if (print_flag) {
     puts(decoding.asm_buf);

--- a/src/monitor/diff-test/protocol.c
+++ b/src/monitor/diff-test/protocol.c
@@ -73,7 +73,7 @@ uint64_t gdb_decode_hex_str(uint8_t *bytes) {
 
 
 static struct gdb_conn* gdb_begin(int fd) {
-  struct gdb_conn *conn = calloc(1, sizeof(struct gdb_conn *));
+  struct gdb_conn *conn = calloc(1, sizeof(struct gdb_conn));
   if (conn == NULL)
     err(1, "calloc");
 


### PR DESCRIPTION
我校课程使用nemu 2017版本进行实验，2017版本中nemu框架两处位置会在最新编译器中提示warning，因Werror转为error。这里两处问题我认为应该不是教学目标，所以提一个patch修复

+ src/cpu/exec/exec.c：
nemu_backup/include/cpu/decode.h中`DecodeInfo`结构体有`assembly`和`asm_buf`两个char数组：
```c
typedef struct {
  uint32_t opcode;
  vaddr_t seq_eip;  // sequential eip
  bool is_operand_size_16;
  uint8_t ext_opcode;
  bool is_jmp;
  vaddr_t jmp_eip;
  Operand src, dest, src2;
#ifdef DEBUG
  char assembly[80];
  char asm_buf[128];
  char *p;
#endif
} DecodeInfo;
```
在`src/cpu/exec/exec.c`中执行了
```c
strcat(decoding.asm_buf, decoding.assembly);
```
这里编译器会报警：
```
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:130:10: error: ‘__builtin___strcat_chk’ accessing 81 or more bytes at offsets 264 and 184 may overlap 1 byte at offset 264 [-Werror=restrict]
  130 |   return __builtin___strcat_chk (__dest, __src, __glibc_objsize (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:25: build/obj/cpu/exec/exec.o] Error 1
```
安全起见这里改为strncat

+ nemu/src/monitor/diff-test/protocol.c：
calloc 使用错误
```c
static struct gdb_conn* gdb_begin(int fd) {
  struct gdb_conn *conn = calloc(1, sizeof(struct gdb_conn *));
  if (conn == NULL)
    err(1, "calloc");
```
