### PR TITLE
Add LA32r disassemble framework.

### DIFF
--- a/src/cpu/cpu-exec.c
+++ b/src/cpu/cpu-exec.c
@@ -66,7 +66,8 @@ static void exec_once(Decode *s, vaddr_t pc) {
   disassemble(p, s->logbuf + sizeof(s->logbuf) - p,
       MUXDEF(CONFIG_ISA_x86, s->snpc, s->pc), (uint8_t *)&s->isa.inst.val, ilen);
 #else
-  p[0] = '\0'; // the upstream llvm does not support loongarch32r
+  void disassem_la(char *str, uint32_t code);
+  disassem_la(p, s->isa.inst.val);
 #endif
 #endif
 }

--- a/src/isa/loongarch32r/disassem_la.c
+++ b/src/isa/loongarch32r/disassem_la.c
@@ -1,0 +1,29 @@
+#include<disassem_la.h>
+extern const char *regs[];
+static uint32_t GetInst(char *inst, uint32_t code){
+    uint32_t opcode_31_25 = BITS(code, 31, 25);
+
+    if (opcode_31_25 == PCADDU12I) {strcpy(inst, "pcaddu12i");return TYPE_1RI20;}
+    else { strcpy(inst,"\0");return TYPE_N;}
+}
+void disassem_la(char *str, uint32_t code){
+        char inst[30];
+        uint32_t type =  GetInst(inst,code);
+        Assert(inst!=NULL,"GetInst false.");
+
+        char p[20];
+        int rd = BITS(code, 4, 0);
+
+        switch (type)
+        {
+        case TYPE_1RI20:
+            int imm = SEXT(BITS(code, 24, 5), 20) << 12;
+            sprintf(p,"  %s, %d",regs[rd],imm);
+            break;
+        default:
+            p[0] = '\0';
+            break;
+        }
+        strcat(inst,p);
+        strcpy(str,inst);
+}

--- a/src/isa/loongarch32r/include/disassem_la.h
+++ b/src/isa/loongarch32r/include/disassem_la.h
@@ -1,0 +1,8 @@
+#ifndef __DISASSEM_LA__
+#define __DISASSEM_LA__
+    #include <isa-def.h>
+    #include "../local-include/reg.h"
+
+    #define PCADDU12I 0x0e
+
+#endif

--- a/src/isa/loongarch32r/include/isa-def.h
+++ b/src/isa/loongarch32r/include/isa-def.h
@@ -32,4 +32,9 @@ typedef struct {
 
 #define isa_mmu_check(vaddr, len, type) (MMU_DIRECT)
 
+enum {
+  TYPE_2RI12, TYPE_1RI20,
+  TYPE_N, // none
+};
+
 #endif

--- a/src/isa/loongarch32r/inst.c
+++ b/src/isa/loongarch32r/inst.c
@@ -17,15 +17,11 @@
 #include <cpu/cpu.h>
 #include <cpu/ifetch.h>
 #include <cpu/decode.h>
+#include "isa.h"
 
 #define R(i) gpr(i)
 #define Mr vaddr_read
 #define Mw vaddr_write
-
-enum {
-  TYPE_2RI12, TYPE_1RI20,
-  TYPE_N, // none
-};
 
 #define src1R()  do { *src1 = R(rj); } while (0)
 #define simm12() do { *imm = SEXT(BITS(i, 21, 10), 12); } while (0)


### PR DESCRIPTION
添加LA32r反汇编器框架。后面的同学可以在此基础上，后面完善该反汇编器，从而解决llvm 不支持 LA32r ，log只有十六进制机器码的问题。