### PR TITLE
Fix linking issues on macOS

### DIFF
--- a/src/device/filelist.mk
+++ b/src/device/filelist.mk
@@ -27,6 +27,6 @@ SRCS-BLACKLIST-$(CONFIG_TARGET_AM) += src/device/alarm.c
 
 ifdef CONFIG_DEVICE
 ifndef CONFIG_TARGET_AM
-LIBS += -lSDL2
+LIBS += $(shell sdl2-config --libs)
 endif
 endif

--- a/src/utils/filelist.mk
+++ b/src/utils/filelist.mk
@@ -16,5 +16,6 @@
 ifneq ($(CONFIG_ITRACE)$(CONFIG_IQUEUE),)
 CXXSRC = src/utils/disasm.cc
 CXXFLAGS += $(shell llvm-config --cxxflags) -fPIE
+LDFLAGS += -L$(shell llvm-config --libdir)
 LIBS += $(shell llvm-config --libs)
 endif


### PR DESCRIPTION
This pull request addresses compile issues encountered on macOS by updating the configuration for SDL2 and LLVM.

Changes include:
- Using `sdl2-config --libs` to retrieve SDL2 linker flags. This ensures that the correct SDL2 linker flags are used based on the system's SDL2 configuration, resolving linking issues on macOS.
- Adding the LLVM library directory to `LDFLAGS` in filelist.mk. This ensures that the linker can find the necessary LLVM libraries during the build process, fixing related issues on macOS().

The issues on macOS were caused by the installation paths of these packages being different from those on typical Linux systems, leading to linking problems during compiling.

These updates have been tested on:
- macOS
- Orbstack aarch64 Ubuntu virtual machine

The changes can also improve the build process's compatibility