### PR TITLE
Fix: Update hardcoded libcapstone.so.5 to libcapstone.so.6

### DIFF
--- a/src/utils/disasm.c
+++ b/src/utils/disasm.c
@@ -25,7 +25,7 @@ static csh handle;
 
 void init_disasm() {
   void *dl_handle;
-  dl_handle = dlopen("tools/capstone/repo/libcapstone.so.5", RTLD_LAZY);
+  dl_handle = dlopen("tools/capstone/repo/libcapstone.so.6", RTLD_LAZY);
   assert(dl_handle);
 
   cs_err (*cs_open_dl)(cs_arch arch, cs_mode mode, csh *handle) = NULL;


### PR DESCRIPTION
上游更新版本到6了
https://github.com/capstone-engine/capstone/releases/tag/6.0.0-Alpha1
导致tools/capstone/repo目录下只有libcapstone.so.6文件，而没有libcapstone.so.5。
而在src/utils/disasm.c文件中，NEMU尝试加载libcapstone.so.5库文件：
所以我修改了src/utils/disasm.c，使其加载so.6而非6