### PR TITLE
fix: allocate `cfg` on heap area instead of stack

### DIFF
--- a/tools/spike-diff/difftest.cc
+++ b/tools/spike-diff/difftest.cc
@@ -102,7 +102,7 @@ __EXPORT void difftest_exec(uint64_t n) {
 __EXPORT void difftest_init(int port) {
   difftest_htif_args.push_back("");
   const char *isa = "RV" MUXDEF(CONFIG_RV64, "64", "32") MUXDEF(CONFIG_RVE, "E", "I") "MAFDC";
-  cfg_t cfg(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
+  cfg_t *cfg = new cfg_t(/*default_initrd_bounds=*/std::make_pair((reg_t)0, (reg_t)0),
             /*default_bootargs=*/nullptr,
             /*default_isa=*/isa,
             /*default_priv=*/DEFAULT_PRIV,
@@ -114,7 +114,7 @@ __EXPORT void difftest_init(int port) {
             /*default_hartids=*/std::vector<size_t>(1),
             /*default_real_time_clint=*/false,
             /*default_trigger_count=*/4);
-  s = new sim_t(&cfg, false,
+  s = new sim_t(cfg, false,
       difftest_mem, difftest_plugin_devices, difftest_htif_args,
       difftest_dm_config, nullptr, false, NULL,
       false,


### PR DESCRIPTION
在`tools/spike-diff/difftest.cc`中创建cfg时候, 不应该将其分配在栈上, 会导致悬垂指针问题, 应该将其分配在堆或全局段上.
在创建`sim_t`与`processor_t`对象时候, 均是浅拷贝, 而非深拷贝. 
而`cfg`并不仅仅用在创建对象时, 在判断处理器是否支持对齐访存时候, 需要使用到`cfg.misaligned`来检查处理器是否支持非对齐访存, 造成错误的触发或不触发<load/store>_address_misalign.
```cpp
// mmu.h:277
int is_misaligned_enabled()
{
  return proc && proc->get_cfg().misaligned;
}
```
```cpp
// sim.cc
sim_t::sim_t(const cfg_t *cfg, bool halted,
             std::vector<std::pair<reg_t, mem_t*>> mems,
             std::vector<std::pair<reg_t, abstract_device_t*>> plugin_devices,
             const std::vector<std::string>& args,
             const debug_module_config_t &dm_config,
             const char *log_path,
             bool dtb_enabled, const char *dtb_file,
             bool socket_enabled,
             FILE *cmd_file, // needed for command line option --cmd
             bool is_diff_ref)
  : ...
    cfg(cfg), 
  ...
{
//...
}
```
```cpp
// processor.cc
processor_t::processor_t(const isa_parser_t *isa, const cfg_t *cfg,
                         simif_t* sim, uint32_t id, bool halt_on_reset,
                         FILE* log_file, std::ostream& sout_)
  : ... cfg(cfg), ...
{
// ...
}
```