### PR TITLE
fix: Log Macro will print to console twice if no log_file was given w…

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -60,7 +60,7 @@ uint64_t get_time();
   do { \
     extern FILE* log_fp; \
     extern bool log_enable(); \
-    if (log_enable() && log_fp != NULL) { \
+    if (log_enable() && log_fp != NULL && !use_stdout) { \
       fprintf(log_fp, __VA_ARGS__); \
       fflush(log_fp); \
     } \

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -19,6 +19,7 @@ extern uint64_t g_nr_guest_inst;
 
 #ifndef CONFIG_TARGET_AM
 FILE *log_fp = NULL;
+bool use_stdout = true;
 
 void init_log(const char *log_file) {
   log_fp = stdout;
@@ -26,6 +27,7 @@ void init_log(const char *log_file) {
     FILE *fp = fopen(log_file, "w");
     Assert(fp, "Can not open '%s'", log_file);
     log_fp = fp;
+    use_stdout = false;
   }
   Log("Log is written to %s", log_file ? log_file : "stdout");
 }


### PR DESCRIPTION
老师您好。
在学习为NPC搭建基础设施时，很自然地想到复用NEMU中的基础设施，于是选择性地将部分NEMU的源文件与NPC一起编译。在移植`log.c`的过程中，发现当日志文件没有在命令行中被指定，即`log_fp`被设置为`stdout`时，后续Log宏都会被打印两遍，此事在之前的双周分享会中亦有记载：

【可不可以优雅地复用NEMU的代码 - 任勤博 - 一生一芯双周分享会】 https://www.bilibili.com/video/BV168DHY8EtJ

原因应该是`printf`打印了一遍，`fprintf`又向指向`stdout`的`stream`打了一遍。

修复过程中，尝试了在`log_write(...)`的判断条件中加入：
1. `log_fp != stdout`
2. `!isatty(fileno(fp))`

来让`log_fp`指向`stdout`时只输出一次，均会触发段错误，具体原理暂时未知。
目前的处理方式是权宜之计，应该会有更好的解决方案。

感谢阅读。
