### PR TITLE
fix: re-port for macOS (dylib of disasm)

### DIFF
--- a/src/utils/disasm.c
+++ b/src/utils/disasm.c
@@ -17,6 +17,14 @@
 #include <capstone/capstone.h>
 #include <common.h>
 
+#if defined(__APPLE__)
+#define CS_LIB_SUFFIX "5.dylib"
+#elif defined(__linux__)
+#define CS_LIB_SUFFIX "so.5"
+#else
+#error "Unsupported platform"
+#endif
+
 static size_t (*cs_disasm_dl)(csh handle, const uint8_t *code,
     size_t code_size, uint64_t address, size_t count, cs_insn **insn);
 static void (*cs_free_dl)(cs_insn *insn, size_t count);
@@ -25,7 +33,7 @@ static csh handle;
 
 void init_disasm() {
   void *dl_handle;
-  dl_handle = dlopen("tools/capstone/repo/libcapstone.so.5", RTLD_LAZY);
+  dl_handle = dlopen("tools/capstone/repo/libcapstone." CS_LIB_SUFFIX, RTLD_LAZY);
   assert(dl_handle);
 
   cs_err (*cs_open_dl)(cs_arch arch, cs_mode mode, csh *handle) = NULL;

--- a/tools/capstone/Makefile
+++ b/tools/capstone/Makefile
@@ -15,7 +15,15 @@
 
 REPO_PATH = repo
 ifeq ($(wildcard repo/include/capstone/capstone.h),)
-  $(shell git clone --depth=1 -b 5.0.3 git@github.com:capstone-engine/capstone.git $(REPO_PATH))
+  $(shell git clone --depth=1 -b 5.0.6 git@github.com:capstone-engine/capstone.git $(REPO_PATH))
+endif
+
+ifeq ($(shell uname -s),Linux)
+suffix = so.5
+else ifeq ($(shell uname -s),Darwin)
+suffix = 5.dylib
+else
+  $(error Unsupported OS ($(shell uname -s)))
 endif
 
 CAPSTONE = $(REPO_PATH)/libcapstone.so.5


### PR DESCRIPTION
References:
- https://github.com/capstone-engine/capstone/tree/next/xcode
```markdown
The *Capstone.xcodeproj* project is an Xcode project that mimics the Visual
Studio solution for Capstone. It embeds nicely into Xcode workspaces. It has 13
targets, two of which are the most likely to be of interest:

* CapstoneStatic, producing `libcapstone.a`, Capstone as a static library;
* CapstoneDynamic, producing `libcapstone.dylib`, Capstone as a shared library;
* test, test_arm, test_aarch64, test_detail, test_mips, test_ppc, test_skipdata,
	test_sparc, test_systemz, test_xcore, testing all the things.
```
- https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/UsingDynamicLibraries.html
- https://stackoverflow.com/questions/2339679/what-are-the-differences-between-so-and-dylib-on-macos
