### PR TITLE
修复：解决严格别名（Strict Aliasing）违规问题，提升 -O2 优化下的稳定性

### DIFF
--- a/include/device/map.h
+++ b/include/device/map.h
@@ -19,7 +19,7 @@
 #include <cpu/difftest.h>
 
 typedef void(*io_callback_t)(uint32_t, int, bool);
-uint8_t* new_space(int size);
+void* new_space(int size);
 
 typedef struct {
   const char *name;

--- a/include/macro.h
+++ b/include/macro.h
@@ -108,3 +108,28 @@
     ioe_write(reg, &__io_param); })
 
 #endif
+
+/**
+ * @brief 对一个变量的位模式进行类型重解释，类似于 C++20 的 std::bit_cast。
+ * @note  此宏使用了GCC/Clang的语句表达式扩展，以便在表达式中使用。
+ * @param dest_type 目标类型。
+ * @param src   源变量（不是指针）。
+ * @return 一个类型为 dest_type 的新值，其位模式与 src 相同。
+ */
+#if __STDC_VERSION__ >= 201112L
+#define BITCAST(dest_type, src) \
+    ({ \
+        _Static_assert(sizeof(dest_type) == sizeof(src), "Bitcast types must have the same size"); \
+        dest_type dest; \
+        memcpy(&dest, &src, sizeof(dest)); \
+        dest; \
+    })
+#else
+#define BITCAST(dest_type, src) \
+    ({ \
+        assert(sizeof(dest_type) == sizeof(src) && "Bitcast types must have the same size"); \
+        dest_type dest; \
+        memcpy(&dest, &src, sizeof(dest)); \
+        dest; \
+    })
+#endif

--- a/include/memory/host.h
+++ b/include/memory/host.h
@@ -19,22 +19,20 @@
 #include <common.h>
 
 static inline word_t host_read(void *addr, int len) {
+  word_t ret = 0; 
   switch (len) {
-    case 1: return *(uint8_t  *)addr;
-    case 2: return *(uint16_t *)addr;
-    case 4: return *(uint32_t *)addr;
-    IFDEF(CONFIG_ISA64, case 8: return *(uint64_t *)addr);
+    case 1: case 2: case 4: IFDEF(CONFIG_ISA64, case 8: )
+    memcpy(&ret, addr, len); break;
     default: MUXDEF(CONFIG_RT_CHECK, assert(0), return 0);
   }
+  return ret;
 }
 
 static inline void host_write(void *addr, int len, word_t data) {
   switch (len) {
-    case 1: *(uint8_t  *)addr = data; return;
-    case 2: *(uint16_t *)addr = data; return;
-    case 4: *(uint32_t *)addr = data; return;
-    IFDEF(CONFIG_ISA64, case 8: *(uint64_t *)addr = data; return);
-    IFDEF(CONFIG_RT_CHECK, default: assert(0));
+    case 1:  case 2: case 4: IFDEF(CONFIG_ISA64, case 8: )
+    memcpy(addr, &data, len); return;
+    default: IFDEF(CONFIG_RT_CHECK,  assert(0));
   }
 }
 


### PR DESCRIPTION
### 修复：解决严格别名（Strict Aliasing）违规问题，提升 -O2 优化下的稳定性

**关联 Issue：** https://github.com/NJU-ProjectN/ics-pa/issues/35

#### 概述

本次 Pull Request 系统性地解决了 NEMU 代码库中存在的严格别名（Strict Aliasing）违规问题。主要目标是增强代码在高级别编译器优化（如 `-O2`）下的稳定性和行为可预测性。

#### 主要修复内容

1.  **修正 `new_space` 函数签名**
    * 将 `new_space` 函数的返回值从 `uint8_t*` 修正为更通用的 `void*`。这使其与标准内存分配函数（如 `malloc`）的行为保持一致，解决了最明显的类型安全隐患，允许调用者在不违反别名规则的情况下安全地进行类型转换。

2.  **使用 `memcpy` 替代不安全的指针类型转换**
    * 通过正则表达式搜索（`\([\w\s]+\s*\*+\s*\)`）和人工代码审查，定位并重构了多处违反严格别名规则的指针类型强转（Type Punning）代码。
    * 除 `char*` 与 `uint8_t*` 之外，所有直接的内存重解释操作（如 `*(uint32_t*)addr`）均被替换为 `memcpy`，以确保安全地以不同类型访问内存区域。

#### 重要说明

本次提交中对 `tools/kvm-diff/src/kvm.c` 文件的修改，主要是为了遵循严格别名规则以消除潜在风险。由于缺乏相应的 KVM 测试环境，这些变更**尚未经过实际运行测试**，其功能正确性有待进一步验证。

#### 关于 `-Wstrict-aliasing` 编译警告的说明

在修复过程中，曾尝试添加 `-fstrict-aliasing -Wstrict-aliasing=3` 编译选项以辅助定位问题。

* 实验发现，该选项在 **C++ (`g++`)** 代码中能够有效工作并报告部分违规。
* 然而，在项目的 **C (`gcc`)** 代码中，无论设置何种优化等级，此警告均未能按预期触发。

鉴于该警告在 C 语言环境中并不可靠，本次 PR **并未**将相关编译选项添加到构建系统中。

#### 补充说明

此外， [abstract-machine](https://github.com/NJU-ProjectN/abstract-machine) 的代码库中也存在大量严格别名违规。由于本人目前对该am代码的理解尚不深入，暂时不参与修复。