### PR TITLE
device, vga: Fix unused-function error for update_screen()

### DIFF
--- a/include/macro.h
+++ b/include/macro.h
@@ -97,6 +97,8 @@
 #define unlikely(cond) __builtin_expect(cond, 0)
 #endif
 
+#define UNUSED __attribute__((unused))
+
 // for AM IOE
 #define io_read(reg) \
   ({ reg##_T __io_param; \

--- a/src/device/vga.c
+++ b/src/device/vga.c
@@ -56,6 +56,9 @@ static void init_screen() {
   SDL_RenderPresent(renderer);
 }
 
+// TODO: remove this line after vga_update_screen() is finished
+static inline void update_screen() UNUSED;
+
 static inline void update_screen() {
   SDL_UpdateTexture(texture, NULL, vmem, SCREEN_W * sizeof(uint32_t));
   SDL_RenderClear(renderer);


### PR DESCRIPTION
The following error happens on some compilers if vga_update_screen() is not finished

src/device/vga.c:59:20: error: unused function 'update_screen' [-Werror,-Wunused-function]
   59 | static inline void update_screen() {
      |

Students may remove the "static inline void update_screen() UNUSED;" line after they've finished vga_update_screen()